### PR TITLE
refresh interface map if the current interface isn't found

### DIFF
--- a/networkd-notify
+++ b/networkd-notify
@@ -107,6 +107,9 @@ def property_changed(typ, data, _, path):
     # http://thread.gmane.org/gmane.comp.sysutils.systemd.devel/36460
     idx = path[32:]
     idx = int(chr(int(idx[:2], 16)) + idx[2:])
+
+    if idx not in IFACE_MAP:
+        update_iface_map()
     iface = IFACE_MAP[idx]
 
     hstate = STATE_MAP.get(state, state)


### PR DESCRIPTION
fixes #4

we only update the interface map upon encountering an interface that
isn't in there yet, so as to avoid running the costly update at each
notification, but still getting mostly up-to-date info.